### PR TITLE
SPIKE: Readme source of truth for config dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The default locations for the Obsidian configuration directory:
 
 - Mac, `/Users/<username>/Library/Application Support/obsidian`
 - Linux, `/home/<username>/.config/obsidian`
+- Linux, `/home/<username>/.var/app/md.obsidian.Obsidian/config/obsidian` (alternate installation location)
 - Windows, `C:\Users\<username>\AppData\obsidian`
 
 If the `--list` option doesn't show your vaults or if you want OSM to use an alternate Obsidian configuration, use the `--root` option:


### PR DESCRIPTION
This is branched off on #5 since is uses some of the minor formatting changes there.
And thus also contains those commits.

This "works for me", bu the real question is how can we have but one source of truth for the list of configuration directories to check. This is just one idea.

@peterkaminski - not urgent, but I would like some solution so that my default is considered and I don't have set the env var except for testing :-)
