### PR TITLE
Make the 'nuke' option a separate option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## WARNING AND DISCLAIMER
 
-WARNING: This utility manipulates files in all vaults that Obsidian knows about. It is written to only fiddle with the files in .obsidian (and with the `--rm` flag, to delete the `.obsidian` directory and recreate it), and it is intended to be safe to use. HOWEVER, it is possible that unintentional data loss may occur, and so you should only use this utility if you have backups of all your files, and only if you understand the risks associated with using this utility.
+WARNING: This utility manipulates files in all vaults that Obsidian knows about. It is written to only fiddle with the files in .obsidian (and with the `--exact-copy-of` flag, to delete the `.obsidian` directory and recreate it), and it is intended to be safe to use. HOWEVER, it is possible that unintentional data loss may occur, and so you should only use this utility if you have backups of all your files, and only if you understand the risks associated with using this utility.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
@@ -97,7 +97,7 @@ In this example, there is an Obsidian vault directory at `Vaults/obsidian-settin
 
 The default operation is to rename existing files so they have a date string appended, as a simple backup, to avoid data loss.  For example, the file `config` would be renamed to something like `config-2021-05-23T23:57:24.141428Z`.  Other files in the `.obsidian` directory are not affected.
 
-If you prefer, you can have the utility nuke the whole `.obsidian` directory, and then create a new empty directory, to copy files into.  This reduces the clutter of the backups, at the expense of losing everything in the directory (including, for instance, `workspace` settings).  Obsidian is good about recreating files it needs in the directory, but please use `--rm` only if you understand the implications. In particular, consider making a separate backup of important `config` files from customized vaults.
+If you prefer, you can have the utility nuke the whole `.obsidian` directory, and then create a new empty directory, to copy files into.  This reduces the clutter of the backups, at the expense of losing everything in the directory (including, for instance, `workspace` settings).  Obsidian is good about recreating files it needs in the directory, but please use `--exact-copy-of` only if you understand the implications. In particular, consider making a separate backup of important `config` files from customized vaults. Also, do not use this option while Obsidian is running!
 
 The files and directories currently copied (as long as they exist in the source vault):
 

--- a/osm.py
+++ b/osm.py
@@ -64,7 +64,7 @@ def init_argparse():
     only_one_of = parser.add_mutually_exclusive_group(required=True)
     only_one_of.add_argument('--list', '-l', action='store_true', help='list Obsidian vaults')
     only_one_of.add_argument('--update', '-u', help='update Obsidian vaults from UPDATE vault')
-    only_one_of.add_argument('--exact-copy-of', help='delete and recreate Obsidian vaults with an exact copy of OVERWRITE vault')
+    only_one_of.add_argument('--exact-copy-of', help='delete and recreate Obsidian vaults with an exact copy of the EXACT_COPY_OF vault')
     only_one_of.add_argument('--diff-to', '-d', help='Like update but instead of copying, just show a diff against DIFF_TO instead (no changes made).')
     only_one_of.add_argument('--execute', '-x', help='run EXECUTE command within each vault (use caution!)')
     only_one_of.add_argument('--backup-list', action='store_true', help='list ISO 8601-formatted .obsidian backup files from all vaults')

--- a/osm.py
+++ b/osm.py
@@ -61,10 +61,10 @@ def init_argparse():
     parser.add_argument('--verbose', action='store_true', help='Print what the file system operations are happening')
     parser.add_argument('--dry-run', '-n', action='store_true', help='Do a dry-run. Show what would be done, without doing it.')
     parser.add_argument('--root', default=OBSIDIAN_ROOT_DIR, help=f'Use an alternative Obsidian Root Directory (default {OBSIDIAN_ROOT_DIR!r})')
-    parser.add_argument('--rm', action='store_true', help='with --update, remove .obsidian and create again, rather than retain old .obsidian files')
     only_one_of = parser.add_mutually_exclusive_group(required=True)
     only_one_of.add_argument('--list', '-l', action='store_true', help='list Obsidian vaults')
     only_one_of.add_argument('--update', '-u', help='update Obsidian vaults from UPDATE vault')
+    only_one_of.add_argument('--exact-copy-of', help='delete and recreate Obsidian vaults with an exact copy of OVERWRITE vault')
     only_one_of.add_argument('--diff-to', '-d', help='Like update but instead of copying, just show a diff against DIFF_TO instead (no changes made).')
     only_one_of.add_argument('--execute', '-x', help='run EXECUTE command within each vault (use caution!)')
     only_one_of.add_argument('--backup-list', action='store_true', help='list ISO 8601-formatted .obsidian backup files from all vaults')
@@ -117,10 +117,10 @@ def ensure_valid_vault(vault_paths, vault_to_check):
     call_for_each_vault(vault_paths, show_vault_path)
     exit(-1)
 
-def call_for_each_vault(vault_paths, operation, *args):
-    '''Call operation with each vault in vault_paths, followed by *args.'''
+def call_for_each_vault(vault_paths, operation, *args, **kwargs):
+    '''Call operation with each vault in vault_paths, followed by *args and **kwargs.'''
     for vault_path in vault_paths:
-        operation(vault_path, *args)
+        operation(vault_path, *args, **kwargs)
 
 def backup(item, suffix):
     '''Rename item to have the given suffix.'''
@@ -192,7 +192,7 @@ def copy_settings_item(suffix, src, dest, itemname):
     else:
         copy_file(src_target, dest_target)
 
-def copy_settings(dest, src, clean_first):
+def copy_settings(dest, src, clean_first=False):
     '''
     Copy the usual settings items into dest vault from src.
 
@@ -300,7 +300,10 @@ def main():
             call_for_each_vault(vault_paths, show_vault_path)
         elif args.update:
             ensure_valid_vault(vault_paths, args.update)
-            call_for_each_vault(vault_paths, copy_settings, Path.home() / args.update, args.rm)
+            call_for_each_vault(vault_paths, copy_settings, Path.home() / args.update, clean_first=False)
+        elif args.exact_copy_of:
+            ensure_valid_vault(vault_paths, args.exact_copy_of)
+            call_for_each_vault(vault_paths, copy_settings, Path.home() / args.exact_copy_of, clean_first=True)
         elif args.diff_to:
             ensure_valid_vault(vault_paths, args.diff_to)
             call_for_each_vault(vault_paths, diff_settings, Path.home() / args.diff_to)


### PR DESCRIPTION
1) Having it be an additional parameter to the update bothered me,
   because it was more awkward to talk about it and left the argparser
   having an option that only applied to one of the other excusive options.
2) Having a better name makes it harder to fumble finger
3) Having no one letter abbreviation makes it harder to braino (--exact-copy-of vs -u --rm)
4) Make the clean_first boolean a named parameter so that is more self documenting.
5) Fix the generic call_for_each_vault to handle kwargs too (shoud have done this initially)

Names are hard, I wanted something long and descriptive to avoid accidental usage, but I'm not wedded to this name.